### PR TITLE
removed unnecessary percentage on paths

### DIFF
--- a/RogueElements/MapGen/Grid/Paths/IGridPathCircle.cs
+++ b/RogueElements/MapGen/Grid/Paths/IGridPathCircle.cs
@@ -206,7 +206,7 @@ namespace RogueElements
 
         public override string ToString()
         {
-            return string.Format("{0}: Fill:{1}% Paths:{2}%", this.GetType().GetFormattedTypeName(), this.CircleRoomRatio, this.Paths);
+            return string.Format("{0}: Fill:{1}% Paths:{2}", this.GetType().GetFormattedTypeName(), this.CircleRoomRatio, this.Paths);
         }
 
         private void RollOpenRoom(IRandom rand, GridPlan floorPlan, Loc loc, ref int roomOpen, ref int maxRooms)


### PR DESCRIPTION
This PR addresses a very minor visual typo discovered in the editor by Palika. Although no issue was ever created for it, here is the discord message associated with this bug. 

_Bug: Editor displays certain ranges as percentages despite them being an actual number_
![image](https://github.com/audinowho/RogueElements/assets/46076580/2c806575-a190-4edf-a6ab-c301980ab77c)
